### PR TITLE
Release v0.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "srpcLib"
-version = "0.0.0"
+version = "0.1.0"
 description = "SRPC is a lightweight Remote Procedure Call (RPC) library."
 authors = [{ name="Oseas Andre", email="oseasandrepro@gmail.com" }]
 dependencies = ["pytest>=8.4.1"]

--- a/srpcLib/stub_generator/srpc_server_stub_gen.py
+++ b/srpcLib/stub_generator/srpc_server_stub_gen.py
@@ -56,10 +56,10 @@ class Srpc{module_name.capitalize()}ServerStub(SrpcServerStubInterface):
         self.__logger.addHandler(self.__console_handler)
 
 
-    def __set_metrics(self, func_name):
-        self.__mestrics.add_metric(func_name, SrpcmetricsTypes.COUNTER_SUCCESS)
-        self.__mestrics.add_metric(func_name, SrpcmetricsTypes.COUNTER_FAIL)
-        self.__mestrics.add_metric(func_name, SrpcmetricsTypes.TIME)
+    def __set_metrics(self, procedure_name):
+        self.__mestrics.add_metric(procedure_name, SrpcmetricsTypes.COUNTER_SUCCESS)
+        self.__mestrics.add_metric(procedure_name, SrpcmetricsTypes.COUNTER_FAIL)
+        self.__mestrics.add_metric(procedure_name, SrpcmetricsTypes.TIME)
 
     def __get_lib_procedures_name(self):
         return [name for name, member in inspect.getmembers({interface_name}, predicate=inspect.isfunction)]
@@ -70,20 +70,20 @@ class Srpc{module_name.capitalize()}ServerStub(SrpcServerStubInterface):
             self.__logger.error("Mission aborted.")
             os._exit(1)
 
-    def __call_func(self, t: tuple):
+    def __call_procedure(self, t: tuple):
         try:
             method = getattr(self.__lib_procedures, t[0])
             return method(*t[1:])
         except AttributeError:
             return None
 
-    def __register_func_in_binder(self, func_name, port):
-        #setting metric for the function
-        self.__set_metrics(func_name)
+    def __register_procedure_in_binder(self, procedure_name, port):
+        #setting metric for Procedure
+        self.__set_metrics(procedure_name)
         try:
             socket_cli = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             socket_cli.connect((self.__host, self.__BINDER_PORT))
-            request = ("REGISTER", func_name, port)
+            request = ("REGISTER", procedure_name, port)
             serialized_request = self.__serializer.serialize(request)
             socket_cli.sendall(serialized_request)
 
@@ -95,13 +95,13 @@ class Srpc{module_name.capitalize()}ServerStub(SrpcServerStubInterface):
 
             socket_cli.close()
         except socket.timeout:
-            self.__logger.error(f"Timeout occurred during RPC bind for function [{{func_name}}].")
+            self.__logger.error(f"Timeout occurred during RPC bind for procedure [{{procedure_name}}].")
         except OSError as e:
-            self.__logger.error(f"An error occurred during function [{{func_name}}] registration: {{e}}")
+            self.__logger.error(f"An error occurred during procedure [{{procedure_name}}] registration: {{e}}")
             self.__logger.error("Mission aborted.")
             os._exit(1)
         except SrpcBinderRequestException as e:
-            self.__logger.error(f"RPC Binder returns an error response during function [{{func_name}}] registration: {{e}}")
+            self.__logger.error(f"RPC Binder returns an error response during procedure [{{procedure_name}}] registration: {{e}}")
             self.__logger.error("Mission aborted.")
             os._exit(1)
 
@@ -110,25 +110,25 @@ class Srpc{module_name.capitalize()}ServerStub(SrpcServerStubInterface):
             try:
                 msg = client_socket.recv(1024)
                 request_tuple = self.__serializer.deserialize(msg)
-                func_name = request_tuple[0]
+                procedure_name = request_tuple[0]
 
                 if isinstance(request_tuple, tuple):
                     self.__logger.info(f"Request: {{request_tuple}} from: {{client_addr[0]}}")
                     start_time = time.time()  # Start time measurement
-                    result = self.__call_func(request_tuple)
+                    result = self.__call_procedure(request_tuple)
                     end_time = time.time()  # End time measurement
                     response = ("200", "", result)
-                    self.__mestrics.inc_counter_success(f"{{func_name}}")
-                    self.__mestrics.record_time(f"{{func_name}}", end_time - start_time)
+                    self.__mestrics.inc_counter_success(f"{{procedure_name}}")
+                    self.__mestrics.record_time(f"{{procedure_name}}", end_time - start_time)
                 else:
                     raise SrpcProcUnvailException("The program cannot support the requested procedure.")
             except SrpcProcUnvailException as e:
-                self.__logger.info(f"Procedure [{{func_name}}] is unavailable: {{e.message}}")
+                self.__logger.info(f"Procedure [{{procedure_name}}] is unavailable: {{e.message}}")
                 response = ("404", e.message, type(e).__name__)
             except Exception as e:
-                self.__logger.error(f"Function [{{func_name}}] call error: {{e}}")
+                self.__logger.error(f"Procedure [{{procedure_name}}] call error: {{e}}")
                 response = ("500", str(e), type(e).__name__)
-                self.__mestrics.inc_counter_fail(f"{{func_name}}")
+                self.__mestrics.inc_counter_fail(f"{{procedure_name}}")
             finally:
                 client_socket.sendall( self.__serializer.serialize(response))
 
@@ -155,8 +155,8 @@ class Srpc{module_name.capitalize()}ServerStub(SrpcServerStubInterface):
         binder_thread = threading.Thread(target=self.__binder.start_binder, name="binder_thread", daemon=True)
         binder_thread.start()
         try:
-            for func_name in self.__lib_procedures_name:
-                self.__register_func_in_binder(func_name, self.__CONNECTION_PORT)
+            for procedure_name in self.__lib_procedures_name:
+                self.__register_procedure_in_binder(procedure_name, self.__CONNECTION_PORT)
 
             t = threading.Thread(None,target=self.__listner,name=f"SRPC Thread-Listener")
             self.__threads.append(t)

--- a/srpcLib/stub_generator/srpc_server_stub_gen.py
+++ b/srpcLib/stub_generator/srpc_server_stub_gen.py
@@ -1,6 +1,6 @@
 import logging
 
-from ..utils.srpc_stub_util import DEFAULT_BINDER_PORT
+from ..utils.srpc_stub_util import DEFAULT_BINDER_PORT, DEFAULT_CONNECTION_PORT
 
 logger = logging.getLogger(__name__)
 log_path = "./srpc_server_metrics.log"
@@ -38,6 +38,7 @@ class Srpc{module_name.capitalize()}ServerStub(SrpcServerStubInterface):
         self.__host = get_lan_ip_or_localhost()
         self.__binder = SrpcServerBinder(self.__host)
         self.__BINDER_PORT = {DEFAULT_BINDER_PORT}
+        self.__CONNECTION_PORT = {DEFAULT_CONNECTION_PORT}
 
         self.__lib_procedures_name = self.__get_lib_procedures_name()
         self.__executor = ThreadPoolExecutor(max_workers=10)
@@ -104,15 +105,15 @@ class Srpc{module_name.capitalize()}ServerStub(SrpcServerStubInterface):
             self.__logger.error("Mission aborted.")
             os._exit(1)
 
-
-    def __handle_request(self, func_name, conn, addr):
-        with conn:
+    def __handle_request(self, client_socket, client_addr):
+        with client_socket:
             try:
-                msg = conn.recv(1024)
+                msg = client_socket.recv(1024)
                 request_tuple = self.__serializer.deserialize(msg)
+                func_name = request_tuple[0]
 
-                if isinstance(request_tuple, tuple) and request_tuple[0] == func_name:
-                    self.__logger.info(f"Request: {{request_tuple}} from: {{addr[0]}}")
+                if isinstance(request_tuple, tuple):
+                    self.__logger.info(f"Request: {{request_tuple}} from: {{client_addr[0]}}")
                     start_time = time.time()  # Start time measurement
                     result = self.__call_func(request_tuple)
                     end_time = time.time()  # End time measurement
@@ -129,25 +130,24 @@ class Srpc{module_name.capitalize()}ServerStub(SrpcServerStubInterface):
                 response = ("500", str(e), type(e).__name__)
                 self.__mestrics.inc_counter_fail(f"{{func_name}}")
             finally:
-                conn.sendall( self.__serializer.serialize(response))
+                client_socket.sendall( self.__serializer.serialize(response))
 
-    def __listen_for_func(self, func_name):
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-            s.bind((self.__host, 0))
-            port = s.getsockname()[1]
-            self.__register_func_in_binder(func_name, port)
-            s.listen()
-            s.settimeout(1.0)
+    def __listner(self):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listner_socket:
+            listner_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            listner_socket.bind((self.__host, self.__CONNECTION_PORT))
+            port = listner_socket.getsockname()[1]
+            listner_socket.listen()
+            listner_socket.settimeout(1.0)
 
             while not self.__stop_event.is_set():
                 try:
-                    conn, addr = s.accept()
-                    self.__executor.submit(self.__handle_request, func_name, conn, addr)
+                    client_socket, client_addr = listner_socket.accept()
+                    self.__executor.submit(self.__handle_request, client_socket, client_addr)
                 except socket.timeout:
                     continue
                 except Exception as e:
-                    self.__logger.error(f"An error occurred while listening for function [{{func_name}}] in port [{{port}}]: {{e}}")
+                    self.__logger.error(f"An error occurred while listening for users requests in port [{{port}}]: {{e}}")
                     os._exit(1)
 
     def start(self):
@@ -156,14 +156,13 @@ class Srpc{module_name.capitalize()}ServerStub(SrpcServerStubInterface):
         binder_thread.start()
         try:
             for func_name in self.__lib_procedures_name:
-                t = threading.Thread(None,
-                    target=self.__listen_for_func,
-                    name=f"Thread-Listener-for-func-{{func_name}}",
-                    args=[func_name]
-                    )
-                self.__threads.append(t)
-                t.start()
-            self.__logger.info(f"SRPC server started [tcp-{{self.__host}}-{DEFAULT_BINDER_PORT}]. press Ctrl+C to stop")
+                self.__register_func_in_binder(func_name, self.__CONNECTION_PORT)
+
+            t = threading.Thread(None,target=self.__listner,name=f"SRPC Thread-Listener")
+            self.__threads.append(t)
+            t.start()
+            self.__logger.info(f"Procedurs call on [tcp-{{self.__host}}:{{self.__CONNECTION_PORT}}].")
+            self.__logger.info(f"press Ctrl+C to stop.")
             stop_event.wait()
         except KeyboardInterrupt:
             self.stop()

--- a/srpcLib/utils/srpc_stub_util.py
+++ b/srpcLib/utils/srpc_stub_util.py
@@ -9,6 +9,7 @@ from types import ModuleType
 logger = logging.getLogger(__name__)
 
 DEFAULT_BINDER_PORT = 5000
+DEFAULT_CONNECTION_PORT = 49152
 
 
 def load_module_from_path(path: str) -> ModuleType:


### PR DESCRIPTION
Issue: [Server stub can bind in a ephemeral available port but bloked by the firewall](https://github.com/oseasandrepro/RPC-LIB/issues/48)

Insted of have multiple listner threads (for each procedure) will have only one, to accept the connection then trigger another to do the computation and send back the response.

It is important to note that all referenced threads gonna run concurrently. Keep in mind the implications of the Global Interpreter Lock (GIL).

check the sketch below:

<img width="1386" height="668" alt="image" src="https://github.com/user-attachments/assets/3acd5a43-f373-4486-8902-c58a9df03364" />