### PR TITLE
Formalize interface definition language and data definition language

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "srpcLib"
-version = "2.0.0"
+version = "2.1.0"
 description = "SRPC is a lightweight Remote Procedure Call (RPC) library."
 authors = [{ name="Oseas Andre", email="oseasandrepro@gmail.com" }]
 dependencies = ["pytest>=8.4.1"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ flake8>=3.4.0
 isort>=5.13.2
 rich>=13.7.0
 msgpack==1.2.1
+mypy>=2.3.0

--- a/srpcLib/stub_generator/srpc_server_stub_gen.py
+++ b/srpcLib/stub_generator/srpc_server_stub_gen.py
@@ -150,7 +150,7 @@ class Srpc{module_name.capitalize()}ServerStub(SrpcServerStubInterface):
         f.write(code)
 
     logger.info(f"Server stub successfully generated: {server_stub_file_name}")
-    logger.info(
-        f"You must implement the Class '{server_class_name}' that implements '{interface_name}', "
-        f"inside '{module_name}.py' file."
-    )
+    # logger.info(
+    #     f"You must implement the Class '{server_class_name}' that implements '{interface_name}', "
+    #     f"inside '{module_name}.py' file."
+    # )

--- a/srpcLib/tools/srpc_stub_gen.py
+++ b/srpcLib/tools/srpc_stub_gen.py
@@ -5,6 +5,7 @@ from os import path
 from ..stub_generator.srpc_client_stub_gen import gen_client_stub
 from ..stub_generator.srpc_server_stub_gen import gen_server_stub
 from ..utils.srpc_stub_util import (
+    check_service_defination,
     get_interface_from_module,
     get_methodname_signature_map_from_interface,
     load_module_from_path,
@@ -33,6 +34,8 @@ if __name__ == "__main__":
     interface = get_interface_from_module(module)
     file_name = path.basename(args.path)
     interface_name = interface.__name__
+
+    check_service_defination(args.path)
 
     gen_client_stub(
         file_name,

--- a/srpcLib/utils/srpc_stub_util.py
+++ b/srpcLib/utils/srpc_stub_util.py
@@ -2,6 +2,7 @@ import importlib.util
 import inspect
 import logging
 import os
+import subprocess
 import sys
 from abc import ABC
 from types import ModuleType
@@ -99,3 +100,42 @@ def build_param_tuple(params: list[str]) -> str:
         return f"({params[0]},)"
     else:
         return f"({', '.join(params)})"
+
+
+def get_service_name(full_interface_path: str):
+    full_interface_path = os.path.basename(full_interface_path).split(".")[0]
+    return full_interface_path.split("_")[0]
+
+
+def get_service_dir(full_interface_path: str):
+    return os.path.dirname(full_interface_path)
+
+
+def check_file_type_hints(file_path: str) -> tuple[bool, str]:
+    result = subprocess.run(
+        ["mypy", "--disallow-untyped-defs", file_path], capture_output=True, text=True
+    )
+    output = result.stdout
+    if output[0:7] == "Success":
+        return True, ""
+    else:
+        return False, output
+
+
+def check_service_defination(full_interface_path: str):
+    service_name = get_service_name(full_interface_path)
+    service_dir = get_service_dir(full_interface_path)
+
+    interface_impl_full_path = f"{service_dir}/{service_name}.py"
+
+    try:
+        passed, msg = check_file_type_hints(full_interface_path)
+        if not passed:
+            raise ValueError(f"Check type hint.\n{msg}")
+
+        passed, msg = check_file_type_hints(interface_impl_full_path)
+        if not passed:
+            raise ValueError(f"Check type hint.\n{msg}")
+    except ValueError as e:
+        logger.error(str(e))
+        exit(1)

--- a/tests/integration/simple_project/calc/calc.py
+++ b/tests/integration/simple_project/calc/calc.py
@@ -11,5 +11,5 @@ class Calc(CalcInterface):
     def mult(self, a: int, b: int) -> int:
         return a * b
 
-    def div(self, a: int, b: int) -> int:
+    def div(self, a: int, b: int) -> float:
         return a / b

--- a/tests/integration/simple_project/calc/calc_interface.py
+++ b/tests/integration/simple_project/calc/calc_interface.py
@@ -15,5 +15,5 @@ class CalcInterface(ABC):
         pass
 
     @abstractmethod
-    def div(self, a: int, b: int) -> int:
+    def div(self, a: int, b: int) -> float:
         pass

--- a/tests/integration/simple_project/calc/calcinconsistent_interface.py
+++ b/tests/integration/simple_project/calc/calcinconsistent_interface.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 
 
-class CalcInterfaceInconsistent(ABC):
+class CalcinconsistentInterface(ABC):
     @abstractmethod
     def add(self, a, b) -> int:
         pass

--- a/tests/integration/test_simple_project.py
+++ b/tests/integration/test_simple_project.py
@@ -121,8 +121,8 @@ def test_type_hint_checker_fail():
         text=True,
     )
 
-    expected_output = "INFO | srpcLib.utils.srpc_stub_util : Module calcinconsistent_interface loaded successfully from /home/saesolab/software-projects/RPC-LIB/tests/integration/simple_project/calc/calcinconsistent_interface.py.\nINFO | srpcLib.utils.srpc_stub_util : Interface CalcinconsistentInterface found in module calcinconsistent_interface.\nERROR | srpcLib.utils.srpc_stub_util : Check type hint.\ncalc/calcinconsistent_interface.py:6: error: Function is missing a type annotation for one or more parameters  [no-untyped-def]\nFound 1 error in 1 file (checked 1 source file)\n\n"
-    assert result.stderr == expected_output, "Expect hint checker fail"
+    expected_output = "INFO | srpcLib.utils.srpc_stub_util : Interface CalcinconsistentInterface found in module calcinconsistent_interface.\nERROR | srpcLib.utils.srpc_stub_util : Check type hint.\ncalc/calcinconsistent_interface.py:6: error: Function is missing a type annotation for one or more parameters  [no-untyped-def]\nFound 1 error in 1 file (checked 1 source file)\n\n"
+    assert result.stderr[-351:] == expected_output, "Expect hint checker fail"
 
 
 def test_type_hint_checker_sucess(generate_stubs):

--- a/tests/integration/test_simple_project.py
+++ b/tests/integration/test_simple_project.py
@@ -15,6 +15,7 @@ STUB_GEN_SCRIPT = "srpcLib.tools.srpc_stub_gen"
 SERVER_STUB_SCRIPT = "srpc_calc_server_stub.py"
 CLIENT_STUB_SCRIPT = "srpc_calc_client_stub.py"
 INTERFACE_DEF = TEST_PROJECT / "calc/calc_interface.py"
+INTERFACE_DEF_INCONSISTENT = TEST_PROJECT / "calc/calcinconsistent_interface.py"
 
 SERVER_SCRIPT = "server.py"
 CLIENT_SCRIPT = "client.py"
@@ -109,6 +110,27 @@ def server_process(generate_stubs, request):
 
     request.addfinalizer(finalizer)
     yield proc
+
+
+def test_type_hint_checker_fail():
+    result = subprocess.run(
+        [sys.executable, "-m", f"{STUB_GEN_SCRIPT}", f"{INTERFACE_DEF_INCONSISTENT}"],
+        cwd=TEST_PROJECT,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    expected_output = "INFO | srpcLib.utils.srpc_stub_util : Module calcinconsistent_interface loaded successfully from /home/saesolab/software-projects/RPC-LIB/tests/integration/simple_project/calc/calcinconsistent_interface.py.\nINFO | srpcLib.utils.srpc_stub_util : Interface CalcinconsistentInterface found in module calcinconsistent_interface.\nERROR | srpcLib.utils.srpc_stub_util : Check type hint.\ncalc/calcinconsistent_interface.py:6: error: Function is missing a type annotation for one or more parameters  [no-untyped-def]\nFound 1 error in 1 file (checked 1 source file)\n\n"
+    assert result.stderr == expected_output, "Expect hint checker fail"
+
+
+def test_type_hint_checker_sucess(generate_stubs):
+    # Assert generated scripts exist
+    server_file = TEST_PROJECT / SERVER_STUB_SCRIPT
+    client_file = TEST_PROJECT / CLIENT_STUB_SCRIPT
+    assert server_file.exists(), f"Missing server stub: {server_file}"
+    assert client_file.exists(), f"Missing client stub: {client_file}"
 
 
 def test_rpc_the_for_operations_of_calc(server_process, generate_stubs):

--- a/tests/test_resources/calc/calc.py
+++ b/tests/test_resources/calc/calc.py
@@ -11,5 +11,5 @@ class Calc(CalcInterface):
     def mult(self, a: int, b: int) -> int:
         return a * b
 
-    def div(self, a: int, b: int) -> int:
+    def div(self, a: int, b: int) -> float:
         return a / b

--- a/tests/test_resources/calc/calc_interface_inconsistent.py
+++ b/tests/test_resources/calc/calc_interface_inconsistent.py
@@ -1,9 +1,9 @@
 from abc import ABC, abstractmethod
 
 
-class CalcInterface(ABC):
+class CalcInterfaceInconsistent(ABC):
     @abstractmethod
-    def add(self, a: int, b: int) -> int:
+    def add(self, a, b) -> int:
         pass
 
     @abstractmethod

--- a/tests/test_resources/calc/calcinconsistent_interface.py
+++ b/tests/test_resources/calc/calcinconsistent_interface.py
@@ -1,0 +1,19 @@
+from abc import ABC, abstractmethod
+
+
+class CalcinconsistentInterface(ABC):
+    @abstractmethod
+    def add(self, a, b) -> int:
+        pass
+
+    @abstractmethod
+    def sub(self, a: int, b: int) -> int:
+        pass
+
+    @abstractmethod
+    def mult(self, a: int, b: int) -> int:
+        pass
+
+    @abstractmethod
+    def div(self, a: int, b: int) -> float:
+        pass

--- a/tests/unit/test_srpc_stub_utils.py
+++ b/tests/unit/test_srpc_stub_utils.py
@@ -26,3 +26,13 @@ class TestSrpcStubUtils:
         path = "tests/test_resources/calc/calc_interface.py"
         module = srpc_stub_util.load_module_from_path(path)
         assert module.__name__ == "calc_interface"
+
+    def test_check_file_type_hints_sucess(self):
+        file_path = "tests/test_resources/calc/calc_interface.py"
+        passed, msg = srpc_stub_util.check_file_type_hints(file_path)
+        assert passed is True
+
+    def test_check_file_type_hints_fail(self):
+        file_path = "tests/test_resources/calc/calc_interface_inconsistent.py"
+        passed, msg = srpc_stub_util.check_file_type_hints(file_path)
+        assert passed is False

--- a/tests/unit/test_srpc_stub_utils.py
+++ b/tests/unit/test_srpc_stub_utils.py
@@ -33,6 +33,6 @@ class TestSrpcStubUtils:
         assert passed is True
 
     def test_check_file_type_hints_fail(self):
-        file_path = "tests/test_resources/calc/calc_interface_inconsistent.py"
+        file_path = "tests/test_resources/calc/calcinconsistent_interface.py."
         passed, msg = srpc_stub_util.check_file_type_hints(file_path)
         assert passed is False


### PR DESCRIPTION
Enforce the use of type hints in service's definition and service's data.

The Idia hers is since SRPC use Python as IDL all content of <module_name>_interface.py and <module_name>.py must use type hint  mandatorily